### PR TITLE
Add validation to prevent multiple active batches per cage

### DIFF
--- a/SmartFarmManager.Service/Services/FarmingBatchService.cs
+++ b/SmartFarmManager.Service/Services/FarmingBatchService.cs
@@ -204,6 +204,16 @@ namespace SmartFarmManager.Service.Services
 
             if (farmingBatch.Status == FarmingBatchStatusEnum.Planning && newStatus == FarmingBatchStatusEnum.Active)
             {
+                // **Kiểm tra xem chuồng này có FarmingBatch nào đang hoạt động không**
+                var activeBatchExists = await _unitOfWork.FarmingBatches
+                    .FindByCondition(fb => fb.CageId == farmingBatch.CageId && fb.Status == FarmingBatchStatusEnum.Active)
+                    .AnyAsync();
+
+                if (activeBatchExists)
+                {
+                    throw new InvalidOperationException($"Chuồng này đã có một FarmingBatch đang hoạt động. Không thể kích hoạt thêm.");
+                }
+
                 // **Chuyển trạng thái sang Active**
                 farmingBatch.Status = FarmingBatchStatusEnum.Active;
                 farmingBatch.StartDate = DateTimeUtils.VietnamNow();


### PR DESCRIPTION
Added a check to ensure that there is no active FarmingBatch in the same cage before changing the status to Active. If an active FarmingBatch already exists in the cage, an InvalidOperationException is thrown to prevent activating another batch in the same cage. This ensures that only one active FarmingBatch can exist per cage at any given time.