### PR TITLE
Remove AnimalType property from Cage-related classes

### DIFF
--- a/SmartFarmManager.API/Controllers/CageController.cs
+++ b/SmartFarmManager.API/Controllers/CageController.cs
@@ -89,7 +89,6 @@ namespace SmartFarmManager.API.Controllers
                     Area = request.Area,
                     Capacity = request.Capacity,
                     Location = request.Location,
-                    AnimalType = request.AnimalType
                 });
 
                 var response = ApiResult<object>.Succeed(new { Id = cageId });
@@ -116,7 +115,6 @@ namespace SmartFarmManager.API.Controllers
                     Area = c.Area,
                     Capacity = c.Capacity,
                     Location = c.Location,
-                    AnimalType = c.AnimalType
                 });
 
                 return Ok(ApiResult<IEnumerable<CageResponse>>.Succeed(responses));
@@ -148,7 +146,6 @@ namespace SmartFarmManager.API.Controllers
                     Area = request.Area,
                     Capacity = request.Capacity,
                     Location = request.Location,
-                    AnimalType = request.AnimalType
                 });
 
                 if (!updated)

--- a/SmartFarmManager.API/Payloads/Requests/Cages/CreateCageRequest.cs
+++ b/SmartFarmManager.API/Payloads/Requests/Cages/CreateCageRequest.cs
@@ -7,7 +7,6 @@
         public double Area { get; set; }
         public int Capacity { get; set; }
         public string Location { get; set; }
-        public string AnimalType { get; set; }
     }
 
     public class UpdateCageRequest : CreateCageRequest { }

--- a/SmartFarmManager.API/Payloads/Responses/Cage/CageResponse.cs
+++ b/SmartFarmManager.API/Payloads/Responses/Cage/CageResponse.cs
@@ -7,6 +7,5 @@
         public double Area { get; set; }
         public int Capacity { get; set; }
         public string Location { get; set; }
-        public string AnimalType { get; set; }
     }
 }

--- a/SmartFarmManager.DataAccessObject/Models/Cage.cs
+++ b/SmartFarmManager.DataAccessObject/Models/Cage.cs
@@ -17,7 +17,6 @@ public partial class Cage : EntityBase
 
     public int Capacity { get; set; }
 
-    public string AnimalType { get; set; }
 
     public string BoardCode { get; set; }
 

--- a/SmartFarmManager.DataAccessObject/Models/SmartFarmContext.cs
+++ b/SmartFarmManager.DataAccessObject/Models/SmartFarmContext.cs
@@ -343,7 +343,6 @@ public partial class SmartFarmContext : DbContext
             entity.HasKey(e => e.Id).HasName("PK__Cages__792D9F9AACADDF50");
 
             entity.Property(e => e.Id).HasDefaultValueSql("(newid())");
-            entity.Property(e => e.AnimalType).HasMaxLength(255);
             entity.Property(e => e.BoardCode)
                 .IsRequired()
                 .HasMaxLength(50);

--- a/SmartFarmManager.Service/BusinessModels/Cages/CageModel.cs
+++ b/SmartFarmManager.Service/BusinessModels/Cages/CageModel.cs
@@ -14,7 +14,6 @@ namespace SmartFarmManager.Service.BusinessModels.Cages
         public double Area { get; set; }
         public int Capacity { get; set; }
         public string Location { get; set; }
-        public string AnimalType { get; set; }
     }
 
 }

--- a/SmartFarmManager.Service/Services/CageService.cs
+++ b/SmartFarmManager.Service/Services/CageService.cs
@@ -43,11 +43,6 @@ namespace SmartFarmManager.Service.Services
                 query = query.Where(c => c.FarmId == request.FarmId.Value);
             }
 
-            if (!string.IsNullOrEmpty(request.AnimalType))
-            {
-                query = query.Where(c => c.AnimalType.Contains(request.AnimalType));
-            }
-
             if (!string.IsNullOrEmpty(request.Name))
             {
                 query = query.Where(c => c.Name.Contains(request.Name));
@@ -153,7 +148,6 @@ namespace SmartFarmManager.Service.Services
                 Area = cage.Area,
                 Location = cage.Location,
                 Capacity = cage.Capacity,
-                AnimalType = cage.AnimalType,
                 BoardCode = cage.BoardCode,
                 BoardStatus = cage.BoardStatus,
                 CreatedDate = cage.CreatedDate,
@@ -204,7 +198,6 @@ namespace SmartFarmManager.Service.Services
                 Area = model.Area,
                 Capacity = model.Capacity,
                 Location = model.Location,
-                AnimalType = model.AnimalType,
                 CreatedDate = DateTimeUtils.VietnamNow(),
             };
 
@@ -226,7 +219,6 @@ namespace SmartFarmManager.Service.Services
                 Area = c.Area,
                 Capacity = c.Capacity,
                 Location = c.Location,
-                AnimalType = c.AnimalType
             });
         }
 
@@ -240,7 +232,6 @@ namespace SmartFarmManager.Service.Services
             cage.Area = model.Area;
             cage.Capacity = model.Capacity;
             cage.Location = model.Location;
-            cage.AnimalType = model.AnimalType;
             cage.ModifiedDate = DateTimeUtils.VietnamNow();
 
             await _unitOfWork.Cages.UpdateAsync(cage);

--- a/SmartFarmManager.Service/Services/FarmingBatchService.cs
+++ b/SmartFarmManager.Service/Services/FarmingBatchService.cs
@@ -404,7 +404,6 @@ namespace SmartFarmManager.Service.Services
                         Capacity = fb.Cage.Capacity,
                         FarmId = fb.Cage.FarmId,
                         Location = fb.Cage.Location,
-                        AnimalType = fb.Cage.AnimalType,
                         Area = fb.Cage.Area
 
                     },


### PR DESCRIPTION
The AnimalType property has been removed from various parts of the codebase, including:
- CageController.cs: No longer set or retrieved in controller methods.
- CreateCageRequest.cs: Removed from the CreateCageRequest class.
- CageResponse.cs: Removed from the CageResponse class.
- Cage.cs: Removed from the Cage entity class.
- SmartFarmContext.cs: Removed from entity configuration.
- CageModel.cs: Removed from the CageModel class.
- CageService.cs: Removed from various methods, including query filters and data mappings.
- FarmingBatchService.cs: Removed from data mapping.

This change reflects a design decision to no longer track or use the AnimalType attribute within the Cage entity and related operations.